### PR TITLE
CVE-2022-42889 at Apache Commons Text 1.8 over #28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     implementation "org.mongodb:mongodb-driver-sync:4.7.1"
     implementation group: 'org.jetbrains', name: 'annotations', version: '15.0'
-    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.8'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     implementation group: 'org.graalvm.js', name: 'js', version: '22.3.1'
     implementation files('libs/JMongosh-0.8.1.jar')
     testImplementation group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
CVE-2022-42889 at Apache Commons Text 1.8 over #28

update Apache Commons Text 1.8 to 1.10.0